### PR TITLE
Add Weights and Biases Logging

### DIFF
--- a/paintskills/detr/engine.py
+++ b/paintskills/detr/engine.py
@@ -14,12 +14,12 @@ from datasets.coco_eval import CocoEvaluator
 from datasets.panoptic_eval import PanopticEvaluator
 
 
-def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
+def train_one_epoch(args, model: torch.nn.Module, criterion: torch.nn.Module,
                     data_loader: Iterable, optimizer: torch.optim.Optimizer,
                     device: torch.device, epoch: int, max_norm: float = 0):
     model.train()
     criterion.train()
-    metric_logger = utils.MetricLogger(delimiter="  ")
+    metric_logger = utils.MetricLogger(args, delimiter="  ")
     metric_logger.add_meter('lr', utils.SmoothedValue(window_size=1, fmt='{value:.6f}'))
     metric_logger.add_meter('class_error', utils.SmoothedValue(window_size=1, fmt='{value:.2f}'))
     header = 'Epoch: [{}]'.format(epoch)
@@ -66,11 +66,11 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
 
 
 @torch.no_grad()
-def evaluate(model, criterion, postprocessors, data_loader, base_ds, device, output_dir):
+def evaluate(args, model, criterion, postprocessors, data_loader, base_ds, device, output_dir):
     model.eval()
     criterion.eval()
 
-    metric_logger = utils.MetricLogger(delimiter="  ")
+    metric_logger = utils.MetricLogger(args, delimiter="  ")
     metric_logger.add_meter('class_error', utils.SmoothedValue(window_size=1, fmt='{value:.2f}'))
     header = 'Test:'
 

--- a/paintskills/detr/main.py
+++ b/paintskills/detr/main.py
@@ -111,6 +111,11 @@ def get_args_parser():
     parser.add_argument('--dataset_file', default='skill')
     parser.add_argument('--skill_name', type=str, default='object')
 
+    # Weights and Biases arguments
+    parser.add_argument("--use_wandb", default=True, type = bool, help = "Whether to use W&B for metric logging")
+    parser.add_argument("--wandb_project", default="DallEval", type=str, help="Name of the W&B Project")
+    parser.add_argument("--wandb_entity", default=None, type=str, help="entity to use for W&B logging")
+
     return parser
 
 
@@ -220,7 +225,7 @@ def main(args):
             args.start_epoch = checkpoint['epoch'] + 1
 
     if args.eval:
-        test_stats, coco_evaluator = evaluate(model, criterion, postprocessors,
+        test_stats, coco_evaluator = evaluate(args, model, criterion, postprocessors,
                                               data_loader_val, base_ds, device, args.output_dir)
         if args.output_dir:
             utils.save_on_master(coco_evaluator.coco_eval["bbox"].eval, output_dir / "eval.pth")
@@ -232,7 +237,7 @@ def main(args):
         if args.distributed:
             sampler_train.set_epoch(epoch)
         train_stats = train_one_epoch(
-            model, criterion, data_loader_train, optimizer, device, epoch,
+            args, model, criterion, data_loader_train, optimizer, device, epoch,
             args.clip_max_norm)
         lr_scheduler.step()
         if args.output_dir:
@@ -250,7 +255,7 @@ def main(args):
                 }, checkpoint_path)
 
         test_stats, coco_evaluator = evaluate(
-            model, criterion, postprocessors, data_loader_val, base_ds, device, args.output_dir
+            args, model, criterion, postprocessors, data_loader_val, base_ds, device, args.output_dir
         )
 
         log_stats = {**{f'train_{k}': v for k, v in train_stats.items()},

--- a/paintskills/detr/requirements.txt
+++ b/paintskills/detr/requirements.txt
@@ -7,3 +7,4 @@ git+https://github.com/cocodataset/panopticapi.git#egg=panopticapi
 scipy
 onnx
 onnxruntime
+wandb


### PR DESCRIPTION
This PR aims to add basic [**Weights and Biases**](https://wandb.ai/site) Metric Logging by appending to the existing `MetricLogger` Class defined in [**`misc.py`**](paintskills/detr/util/misc.py) with minimal changes while supporting Multiple GPU logging with torch distributed. 

The changes can be summarized as follows :-

1. Pass the `args` to the `MetricLogger` which if the `--use_wandb` is set to `True`, creates and run and logs metrics using the `update` function.
2. Add 3 extra arguments namely `--use_wandb`, `--wandb_project` and `--wandb_entity` which can be used to specify whether to use wandb, the name of the project to be used (`"DallEval"` by default) and name of the entity to be used.